### PR TITLE
Make `test_scene_aia` resilient to JSOC network outages

### DIFF
--- a/esis/flights/f1/data/synth/_scene_aia/_scene_aia_test.py
+++ b/esis/flights/f1/data/synth/_scene_aia/_scene_aia_test.py
@@ -18,14 +18,17 @@ def test_scene_aia(
 
     limit = 1
 
-    result = esis.flights.f1.data.synth.scene_aia(
-        axis_detector_x=axis_x,
-        axis_detector_y=axis_y,
-        axis_wavelength=axis_wavelength,
-        axis_velocity=axis_velocity,
-        num_velocity=num_velocity,
-        limit=limit,
-    )
+    try:
+        result = esis.flights.f1.data.synth.scene_aia(
+            axis_detector_x=axis_x,
+            axis_detector_y=axis_y,
+            axis_wavelength=axis_wavelength,
+            axis_velocity=axis_velocity,
+            num_velocity=num_velocity,
+            limit=limit,
+        )
+    except OSError as e:
+        pytest.skip(f"JSOC is unreachable, skipping live-network test: {e}")
 
     assert result.shape[axis_velocity] == num_velocity
     assert result.outputs.unit.is_equivalent(u.erg / u.cm**2 / u.sr / u.AA / u.s)


### PR DESCRIPTION
## Problem

`esis/flights/f1/data/synth/_scene_aia/_scene_aia_test.py::test_scene_aia` performs a **live network query to JSOC** (via `sdo.aia.open`, `_scene_aia.py:97`) to download AIA imagery. CI runners intermittently cannot reach JSOC and fail with:

```
OSError: Unable to query the JSOC.
 Error message: <urlopen error [WinError 10060] A connection attempt failed ...>
```

This lands on a random runner each run, producing flaky red CI on PRs that don't touch this code at all.

## Fix

Wrap the live query in `try/except OSError` and `pytest.skip(...)` on failure. The test still validates the full pipeline when JSOC is reachable; it skips (rather than fails) on a transient network outage. `URLError` and the wrapped `OSError` are both `OSError` subclasses, so both are caught. Non-network errors (e.g. `AttributeError`) still fail loudly.

`fail-fast: false` is already set in the matrix, so no workflow change is needed.

## Notes

A more thorough future option is to cache/record the JSOC response (e.g. `@esis.memory.cache` + a fixture FITS) so the assertions run against recorded data offline. This PR is the minimal stabilization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)