### PR TITLE
Add `scene_iris()` for creating synthetic scenes from IRIS spectroheliograms

### DIFF
--- a/esis/data/synth/__init__.py
+++ b/esis/data/synth/__init__.py
@@ -1,7 +1,9 @@
 """Tools for creating synthetic solar scenes for ESIS analysis."""
 
 from ._scene_aia import scene_aia
+from ._scene_iris import scene_iris
 
 __all__ = [
     "scene_aia",
+    "scene_iris",
 ]

--- a/esis/data/synth/_scene_iris/__init__.py
+++ b/esis/data/synth/_scene_iris/__init__.py
@@ -1,0 +1,5 @@
+from ._scene_iris import scene_iris
+
+__all__ = [
+    "scene_iris",
+]

--- a/esis/data/synth/_scene_iris/_scene_iris.py
+++ b/esis/data/synth/_scene_iris/_scene_iris.py
@@ -1,0 +1,169 @@
+from typing import Literal
+import numpy as np
+import astropy.units as u
+import astropy.time
+import named_arrays as na
+import iris
+
+__all__ = [
+    "scene_iris",
+]
+
+
+def scene_iris(
+    time_start: str | astropy.time.Time,
+    time_stop: None | str | astropy.time.Time,
+    wavelength_rest: u.Quantity,
+    radiance: u.Quantity,
+    fwhm: u.Quantity,
+    axis_time: str = "time",
+    axis_detector_x: str = "detector_x",
+    axis_detector_y: str = "detector_y",
+    axis_velocity: str = "velocity",
+    velocity_max: None | u.Quantity = None,
+    despike: bool = True,
+    background_removal: None | Literal["trim_mean"] = None,
+    dn_min: u.Quantity = 8 * u.DN,
+    dn_zero: u.Quantity = 0.01 * u.DN,
+    **kwargs,
+) -> na.FunctionArray[
+    na.TemporalDopplerPositionalVectorArray,
+    na.ScalarArray,
+]:
+    """
+    Create a synthetic solar scene using IRIS images.
+
+    IRIS spectroheliograms from a specified time range are shifted and scaled
+    to the given wavelength range to simulate a scene observed by ESIS.
+
+    Parameters
+    ----------
+    time_start
+        The start time of the IRIS observations.
+    time_stop
+        The ending time of the IRIS observations.
+        If :obj:`None`, one second is added to `time_start`, which usually
+        has the effect of selecting a single observation.
+    wavelength_rest
+        The new rest wavelength of the simulated scene.
+        This replaces the actual rest wavelength of the IRIS observations.
+    radiance
+        The average radiance of the simulated scene.
+        This replaces the actual radiance of the IRIS observations.
+    fwhm
+        The average full-width half maximum, in wavelength units, of the
+        dominant spectral line in the simulated scene.
+        The wavelength axis of the IRIS observations will be scaled to match
+        this value.
+    axis_time
+        The logical axis corresponding to changes in time.
+    axis_detector_x
+        The logical axis corresponding to changes in detector :math:`x`-coordinate.
+    axis_detector_y
+        The logical axis corresponding to changes in detector :math:`y`-coordinate.
+    axis_velocity
+        The logical axis corresponding to changes in line-of-sight velocity.
+    velocity_max
+        The maximum doppler velocity of the simulated scene.
+        Values outside this range are cropped.
+    despike
+        Whether to remove cosmic ray spikes using :mod:`astroscrappy`.
+    background_removal
+        The background removal algorithm to remove stray light.
+        Currently, the options are :obj:`None` (the default) which is no
+        background removal, and ``trim_mean`` which uses a trimmed mean
+        to estimate a constant background value.
+    dn_min
+        To prevent negatives in the final scene without biasing areas with zero
+        flux, pixels with a value less than `dn_min` will be set to `dn_zero`.
+    dn_zero
+        If a pixel truly has zero flux, this presents a problem since the
+        uncertainty of this pixel is infinite.
+        To prevent this, we interpret "zero flux" as a very small number called
+        `dn_zero`.
+    kwargs
+        Additional keyword arguments passed to :func:`iris.sg.open`
+
+    Raises
+    ------
+    ValueError
+        If `background_removal` is not recognized.
+    """
+    scene = iris.sg.open(
+        time=time_start,
+        time_stop=time_stop,
+        axis_wavelength=axis_velocity,
+        axis_detector_x=axis_detector_x,
+        axis_detector_y=axis_detector_y,
+        **kwargs,
+    )
+
+    scene = scene.explicit
+
+    if despike:
+        scene = na.despike(
+            array=scene,
+            axis=(axis_velocity, axis_detector_y),
+        )
+
+    if background_removal is not None:
+
+        if background_removal == "trim_mean":
+            bg = na.mean_trimmed(
+                a=scene.outputs[np.isfinite(scene.outputs)],
+                q=0.49,
+            )
+
+        else:
+            raise ValueError(f"{background_removal=} not recognized.")
+
+        scene.outputs = scene.outputs - bg
+
+    if velocity_max is not None:
+
+        velocity_centers = scene.inputs.velocity.cell_centers(axis_velocity)
+
+        where_upper = +velocity_max < velocity_centers
+
+        index_lower = np.nanargmax(-velocity_max < velocity_centers)[axis_velocity]
+
+        if where_upper.any():
+            index_upper = np.nanargmax(where_upper)[axis_velocity]
+        else:
+            index_upper = None
+
+        crop_wavelength = {
+            scene.axis_wavelength: slice(index_lower.ndarray, index_upper.ndarray)
+        }
+
+        scene = scene[crop_wavelength]
+
+    scene.outputs = np.nan_to_num(scene.outputs)
+
+    scene.outputs[scene.outputs < dn_min] = dn_zero
+
+    spectrum = scene.mean((axis_time, axis_detector_x, axis_detector_y))
+
+    fwhm_avg = na.pdf.fwhm(
+        x=spectrum.inputs.wavelength,
+        f=spectrum.outputs,
+        axis=axis_velocity,
+    )
+
+    scale = (fwhm / wavelength_rest) / (fwhm_avg / scene.inputs.wavelength_rest)
+
+    scene.inputs = na.TemporalDopplerPositionalVectorArray.from_velocity(
+        velocity=scene.inputs.velocity * scale,
+        wavelength_rest=wavelength_rest,
+        time=scene.inputs.time,
+        position=scene.inputs.position,
+    )
+
+    radiance_avg = scene.integrate(
+        component="wavelength",
+        axis=axis_velocity,
+    ).outputs.mean()
+
+    scene.outputs = scene.outputs * radiance / radiance_avg
+
+    return scene

--- a/esis/data/synth/_scene_iris/_scene_iris.py
+++ b/esis/data/synth/_scene_iris/_scene_iris.py
@@ -114,7 +114,7 @@ def scene_iris(
                 q=0.49,
             )
 
-        else:
+        else:  # pragma: nocover
             raise ValueError(f"{background_removal=} not recognized.")
 
         scene.outputs = scene.outputs - bg

--- a/esis/data/synth/_scene_iris/_scene_iris.py
+++ b/esis/data/synth/_scene_iris/_scene_iris.py
@@ -107,7 +107,6 @@ def scene_iris(
         )
 
     if background_removal is not None:
-
         if background_removal == "trim_mean":
             bg = na.mean_trimmed(
                 a=scene.outputs[np.isfinite(scene.outputs)],
@@ -120,7 +119,6 @@ def scene_iris(
         scene.outputs = scene.outputs - bg
 
     if velocity_max is not None:
-
         velocity_centers = scene.inputs.velocity.cell_centers(axis_velocity)
 
         where_upper = +velocity_max < velocity_centers
@@ -133,9 +131,7 @@ def scene_iris(
         else:
             index_upper = None
 
-        crop_wavelength = {
-            scene.axis_wavelength: slice(index_lower, index_upper)
-        }
+        crop_wavelength = {scene.axis_wavelength: slice(index_lower, index_upper)}
 
         scene = scene[crop_wavelength]
 

--- a/esis/data/synth/_scene_iris/_scene_iris.py
+++ b/esis/data/synth/_scene_iris/_scene_iris.py
@@ -126,14 +126,15 @@ def scene_iris(
         where_upper = +velocity_max < velocity_centers
 
         index_lower = np.nanargmax(-velocity_max < velocity_centers)[axis_velocity]
+        index_lower = index_lower.ndarray
 
         if where_upper.any():
-            index_upper = np.nanargmax(where_upper)[axis_velocity]
+            index_upper = np.nanargmax(where_upper)[axis_velocity].ndarray
         else:
             index_upper = None
 
         crop_wavelength = {
-            scene.axis_wavelength: slice(index_lower.ndarray, index_upper.ndarray)
+            scene.axis_wavelength: slice(index_lower, index_upper)
         }
 
         scene = scene[crop_wavelength]

--- a/esis/flights/f1/data/synth/__init__.py
+++ b/esis/flights/f1/data/synth/__init__.py
@@ -1,7 +1,9 @@
 """Create synthetic solar scenes that can be observed with an instrument model."""
 
 from ._scene_aia import scene_aia
+from ._scene_iris import scene_iris
 
 __all__ = [
     "scene_aia",
+    "scene_iris",
 ]

--- a/esis/flights/f1/data/synth/_scene_iris/__init__.py
+++ b/esis/flights/f1/data/synth/_scene_iris/__init__.py
@@ -1,0 +1,5 @@
+from ._scene_iris import scene_iris
+
+__all__ = [
+    "scene_iris",
+]

--- a/esis/flights/f1/data/synth/_scene_iris/_scene_iris.py
+++ b/esis/flights/f1/data/synth/_scene_iris/_scene_iris.py
@@ -1,0 +1,117 @@
+from typing import Literal
+import astropy.units as u
+import astropy.time
+import named_arrays as na
+import esis
+from ....spectrum import O_V
+
+__all__ = [
+    "scene_iris",
+]
+
+
+def scene_iris(
+    time_start: str | astropy.time.Time,
+    time_stop: None | str | astropy.time.Time = None,
+    wavelength_rest: u.Quantity = O_V.wavelength,
+    radiance: u.Quantity = O_V.radiance,
+    fwhm: u.Quantity = O_V.fwhm,
+    axis_time: str = "time",
+    axis_detector_x: str = "detector_x",
+    axis_detector_y: str = "detector_y",
+    axis_velocity: str = "velocity",
+    velocity_max: None | u.Quantity = 300 * u.km / u.s,
+    despike: bool = True,
+    background_removal: None | Literal["trim_mean"] = None,
+    dn_min: u.Quantity = 8 * u.DN,
+    dn_zero: u.Quantity = 0.01 * u.DN,
+    **kwargs,
+) -> na.FunctionArray[
+    na.TemporalDopplerPositionalVectorArray,
+    na.ScalarArray,
+]:
+    r"""
+    Create a synthetic scene of the :math:`\text{O\,V}\;630\,\AA` spectral line.
+
+    IRIS spectroheliograms from a specified time range are shifted and scaled
+    to the :math:`\text{O\,V}\;630\,\AA` wavelength range to simulate a scene
+    observed by ESIS.
+
+    Parameters
+    ----------
+    time_start
+        The start time of the IRIS observations.
+    time_stop
+        The ending time of the IRIS observations.
+        If :obj:`None`, one second is added to `time_start`, which usually
+        has the effect of selecting a single observation.
+    wavelength_rest
+        The new rest wavelength of the simulated scene.
+        This replaces the actual rest wavelength of the IRIS observations.
+    radiance
+        The average radiance of the simulated scene.
+        This replaces the actual radiance of the IRIS observations.
+    fwhm
+        The average full-width half maximum, in wavelength units, of the
+        dominant spectral line in the simulated scene.
+        The wavelength axis of the IRIS observations will be scaled to match
+        this value.
+    axis_time
+        The logical axis corresponding to changes in time.
+    axis_detector_x
+        The logical axis corresponding to changes in detector :math:`x`-coordinate.
+    axis_detector_y
+        The logical axis corresponding to changes in detector :math:`y`-coordinate.
+    axis_velocity
+        The logical axis corresponding to changes in line-of-sight velocity.
+    velocity_max
+        The maximum doppler velocity of the simulated scene.
+        Values outside this range are cropped.
+    despike
+        Whether to remove cosmic ray spikes using :mod:`astroscrappy`.
+    background_removal
+        The background removal algorithm to remove stray light.
+        Currently, the options are :obj:`None` (the default) which is no
+        background removal, and ``trim_mean`` which uses a trimmed mean
+        to estimate a constant background value.
+    dn_min
+        To prevent negatives in the final scene without biasing areas with zero
+        flux, pixels with a value less than `dn_min` will be set to `dn_zero`.
+    dn_zero
+        If a pixel truly has zero flux, this presents a problem since the
+        uncertainty of this pixel is infinite.
+        To prevent this, we interpret "zero flux" as a very small number called
+        `dn_zero`.
+    kwargs
+        Additional keyword arguments passed to :func:`iris.sg.open`
+
+    Examples
+    --------
+    Load a synthetic :math:`\text{O\,V}\;630\,\AA` scene and display it as
+    a false-color image.
+
+    .. jupyter-execute::
+
+        import esis
+
+        scene = esis.flights.f1.data.synth.scene_iris("2014-07-04 11:40")
+
+        scene.show()
+    """
+    return esis.data.synth.scene_iris(
+        time_start=time_start,
+        time_stop=time_stop,
+        wavelength_rest=wavelength_rest,
+        radiance=radiance,
+        fwhm=fwhm,
+        axis_time=axis_time,
+        axis_detector_x=axis_detector_x,
+        axis_detector_y=axis_detector_y,
+        axis_velocity=axis_velocity,
+        velocity_max=velocity_max,
+        despike=despike,
+        background_removal=background_removal,
+        dn_min=dn_min,
+        dn_zero=dn_zero,
+        **kwargs,
+    )

--- a/esis/flights/f1/data/synth/_scene_iris/_scene_iris.py
+++ b/esis/flights/f1/data/synth/_scene_iris/_scene_iris.py
@@ -96,7 +96,7 @@ def scene_iris(
 
         scene = esis.flights.f1.data.synth.scene_iris("2014-07-04 11:40")
 
-        scene.show()
+        scene.show();
     """
     return esis.data.synth.scene_iris(
         time_start=time_start,

--- a/esis/flights/f1/data/synth/_scene_iris/_scene_iris_test.py
+++ b/esis/flights/f1/data/synth/_scene_iris/_scene_iris_test.py
@@ -1,0 +1,42 @@
+import pytest
+import numpy as np
+import astropy.units as u
+import named_arrays as na
+import esis
+from esis.flights.f1.spectrum import O_V
+
+
+def test_scene_iris():
+
+    axis_time = "time"
+    axis_x = "detector_x"
+    axis_y = "detector_y"
+    axis_txy = (axis_time, axis_x, axis_y)
+    axis_velocity = "velocity"
+
+    try:
+        result = esis.flights.f1.data.synth.scene_iris(
+            time_start="2014-10-13 04:11",
+            axis_time=axis_time,
+            axis_detector_x=axis_x,
+            axis_detector_y=axis_y,
+            axis_velocity=axis_velocity,
+            limit=1,
+        )
+    except OSError as e:
+        pytest.skip(f"IRIS archive is unreachable, skipping live-network test: {e}")
+
+    assert result.outputs.unit.is_equivalent(u.erg / u.cm**2 / u.sr / u.AA / u.s)
+
+    assert np.all(result.inputs.wavelength_rest == O_V.wavelength)
+
+    radiance = result.integrate(component="wavelength", axis=axis_velocity)
+    assert np.allclose(radiance.outputs.mean(), O_V.radiance, rtol=1e-1)
+
+    spectrum = result.mean(axis_txy)
+    fwhm = na.pdf.fwhm(
+        x=spectrum.inputs.wavelength,
+        f=spectrum.outputs,
+        axis=axis_velocity,
+    )
+    assert np.allclose(fwhm, O_V.fwhm, rtol=1e-1)

--- a/esis/flights/f1/data/synth/_scene_iris/_scene_iris_test.py
+++ b/esis/flights/f1/data/synth/_scene_iris/_scene_iris_test.py
@@ -6,7 +6,18 @@ import esis
 from esis.flights.f1.spectrum import O_V
 
 
-def test_scene_iris():
+@pytest.mark.parametrize("background_removal", [None, "trim_mean"])
+@pytest.mark.parametrize(
+    argnames="velocity_max",
+    argvalues=[
+        100 * u.km / u.s,
+        10000 * u.km / u.s,
+    ]
+)
+def test_scene_iris(
+    background_removal: str,
+    velocity_max: None | u.Quantity,
+):
 
     axis_time = "time"
     axis_x = "detector_x"
@@ -22,8 +33,10 @@ def test_scene_iris():
             axis_detector_y=axis_y,
             axis_velocity=axis_velocity,
             limit=1,
+            velocity_max=velocity_max,
+            background_removal=background_removal,
         )
-    except OSError as e:
+    except OSError as e:  # pragma: nocover
         pytest.skip(f"IRIS archive is unreachable, skipping live-network test: {e}")
 
     assert result.outputs.unit.is_equivalent(u.erg / u.cm**2 / u.sr / u.AA / u.s)

--- a/esis/flights/f1/data/synth/_scene_iris/_scene_iris_test.py
+++ b/esis/flights/f1/data/synth/_scene_iris/_scene_iris_test.py
@@ -12,13 +12,12 @@ from esis.flights.f1.spectrum import O_V
     argvalues=[
         100 * u.km / u.s,
         10000 * u.km / u.s,
-    ]
+    ],
 )
 def test_scene_iris(
     background_removal: str,
     velocity_max: None | u.Quantity,
 ):
-
     axis_time = "time"
     axis_x = "detector_x"
     axis_y = "detector_y"

--- a/esis/flights/f1/spectrum/Mg_X.py
+++ b/esis/flights/f1/spectrum/Mg_X.py
@@ -6,6 +6,7 @@ import astropy.units as u
 __all__ = [
     "wavelength",
     "radiance",
+    "fwhm",
     "width_doppler",
 ]
 
@@ -15,11 +16,12 @@ wavelength = 609.793 * u.AA
 #: Average quiet-sun radiance measured by :cite:t:`Vernazza1978`.
 radiance = 125.05 * u.erg / u.cm**2 / u.sr / u.s
 
-_fwhm = 0.138 * u.AA
+#: Average quiet-sun full width at half maximum measured by :cite:t:`Doschek2004`.
+fwhm = 0.138 * u.AA
 
-_width = _fwhm / (2 * np.sqrt(2 * np.log(2)))
+_width = fwhm / (2 * np.sqrt(2 * np.log(2)))
 
 _eq = u.doppler_optical(wavelength)
 
-#: Average quiet-sun Doppler width measured by :cite:t:`Doschek2004`.
+#: Average quiet-sun Doppler width computed from :attr:`fwhm`.
 width_doppler = (wavelength + _width).to(u.km / u.s, equivalencies=_eq)

--- a/esis/flights/f1/spectrum/O_V.py
+++ b/esis/flights/f1/spectrum/O_V.py
@@ -6,6 +6,7 @@ import astropy.units as u
 __all__ = [
     "wavelength",
     "radiance",
+    "fwhm",
     "width_doppler",
 ]
 
@@ -15,11 +16,12 @@ wavelength = 629.732 * u.AA
 #: Average quiet-sun radiance measured by :cite:t:`Vernazza1978`.
 radiance = 334.97 * u.erg / u.cm**2 / u.sr / u.s
 
-_fwhm = 0.129 * u.AA
+#: Average quiet-sun full width at half maximum measured by :cite:t:`Doschek2004`.
+fwhm = 0.129 * u.AA
 
-_width = _fwhm / (2 * np.sqrt(2 * np.log(2)))
+_width = fwhm / (2 * np.sqrt(2 * np.log(2)))
 
 _eq = u.doppler_optical(wavelength)
 
-#: Average quiet-sun Doppler width measured by :cite:t:`Doschek2004`.
+#: Average quiet-sun Doppler width computed from :attr:`fwhm`.
 width_doppler = (wavelength + _width).to(u.km / u.s, equivalencies=_eq)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "optika~=2.0,>=2.0.1",
     "msfc-ccd~=1.0",
     "solar-dynamics-observatory~=1.0",
+    "interface-region-imaging-spectrograph~=1.0,>=1.0.1",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

Adds a new synthetic-scene generator based on real IRIS observations, complementing the existing `scene_aia()`:

- **`esis.data.synth.scene_iris()`** downloads IRIS SG rasters for a time range via `iris.sg.open()`, despikes them with `na.despike`, optionally removes a constant stray-light background (trimmed mean) and crops to a maximum Doppler velocity, clamps near-zero pixels to a small positive value, then rescales the scene so its mean radiance and line FWHM match a target spectral line at a new rest wavelength.
- **`esis.flights.f1.data.synth.scene_iris()`** plugs in the O V 630 Å line properties from `esis.flights.f1.spectrum` to produce a scene as observed by ESIS.

## Implementation notes

- The line-width rescaling normalizes the measured and target FWHM by their respective rest wavelengths before scaling the Doppler velocities, so the relative width is preserved when re-anchoring from the IRIS window (~1394 Å) to O V 630 Å. The inputs are rebuilt with `na.TemporalDopplerPositionalVectorArray.from_velocity()` since `velocity` is a derived property.
- `_fwhm` is promoted to a public `fwhm` attribute in the `O_V` and `Mg_X` spectrum modules; the f1 wrapper uses `O_V.fwhm` as its default.
- Adds `interface-region-imaging-spectrograph~=1.0,>=1.0.1` as a dependency. The `>=1.0.1` floor is required: 1.0.0 raises `KeyError` when `iris.sg.open()` is called with custom axis names (fixed in sun-data/interface-region-imaging-spectrograph#44).

## Testing

- New `_scene_iris_test.py` exercises the f1 wrapper end-to-end against a real IRIS raster and asserts the output units, rest wavelength, mean radiance, and line FWHM match the `O_V` module values. It skips when the IRIS archive is unreachable, mirroring the `scene_aia` test.
- Passes locally in ~6 min; `ruff` and `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xbhx4BAV3jBQBkdCKnfRVK