### PR TITLE
Pass the sensor read noise to the `optika` surface.

### DIFF
--- a/docs/reports/aia-image-simulation.ipynb
+++ b/docs/reports/aia-image-simulation.ipynb
@@ -90,7 +90,7 @@
     "tags": []
    },
    "source": [
-    "Define the logical axis corresponding to changes in line-of-sight velocity."
+    "Define the logical axis corresponding to changes in spectral line"
    ]
   },
   {
@@ -106,7 +106,7 @@
    },
    "outputs": [],
    "source": [
-    "axis_velocity = \"velocity\""
+    "axis_transition = \"transition\""
    ]
   },
   {
@@ -121,7 +121,7 @@
     "tags": []
    },
    "source": [
-    "Define the logical axes corresponding to changes in position on the disk of the Sun."
+    "Define the logical axis corresponding to changes in line-of-sight velocity."
    ]
   },
   {
@@ -137,13 +137,44 @@
    },
    "outputs": [],
    "source": [
+    "axis_velocity = \"velocity\""
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "9",
+   "metadata": {
+    "editable": true,
+    "raw_mimetype": "text/x-rst",
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "Define the logical axes corresponding to changes in position on the disk of the Sun."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
     "axis_x = \"detector_x\"\n",
     "axis_y = \"detector_y\""
    ]
   },
   {
    "cell_type": "raw",
-   "id": "9",
+   "id": "11",
    "metadata": {
     "editable": true,
     "raw_mimetype": "text/x-rst",
@@ -160,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -174,6 +205,7 @@
     "    axis_time=axis_time,\n",
     "    axis_detector_x=axis_x,\n",
     "    axis_detector_y=axis_y,\n",
+    "    axis_wavelength=axis_transition,\n",
     "    axis_velocity=axis_velocity,\n",
     "    limit=1,\n",
     ")"
@@ -181,7 +213,7 @@
   },
   {
    "cell_type": "raw",
-   "id": "11",
+   "id": "13",
    "metadata": {
     "editable": true,
     "raw_mimetype": "text/x-rst",
@@ -197,7 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "14",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -212,7 +244,7 @@
   },
   {
    "cell_type": "raw",
-   "id": "13",
+   "id": "15",
    "metadata": {
     "editable": true,
     "raw_mimetype": "text/x-rst",
@@ -229,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +270,7 @@
   },
   {
    "cell_type": "raw",
-   "id": "15",
+   "id": "17",
    "metadata": {
     "editable": true,
     "raw_mimetype": "text/x-rst",
@@ -254,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "18",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -272,7 +304,7 @@
   },
   {
    "cell_type": "raw",
-   "id": "17",
+   "id": "19",
    "metadata": {
     "editable": true,
     "raw_mimetype": "text/x-rst",
@@ -288,7 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "20",
    "metadata": {
     "editable": true,
     "slideshow": {
@@ -308,7 +340,7 @@
   },
   {
    "cell_type": "raw",
-   "id": "19",
+   "id": "21",
    "metadata": {
     "editable": true,
     "raw_mimetype": "text/x-rst",
@@ -324,14 +356,8 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": []
-   },
+   "id": "22",
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(\n",
@@ -342,7 +368,7 @@
     "img = na.plt.pcolormesh(\n",
     "    images.inputs.position.x,\n",
     "    images.inputs.position.y,\n",
-    "    C=images.outputs.sum((\"wavelength\", axis_velocity)).value,\n",
+    "    C=images.outputs.sum(axis_transition).value,\n",
     "    cmap=\"gray\",\n",
     "    vmin=0,\n",
     "    vmax=vmax,\n",

--- a/esis/optics/_cameras/_cameras.py
+++ b/esis/optics/_cameras/_cameras.py
@@ -53,6 +53,7 @@ class Camera(
             axis_pixel=na.Cartesian2dVectorArray("detector_x", "detector_y"),
             num_pixel=self.sensor.num_pixel_active,
             timedelta_exposure=self.timedelta_exposure,
+            read_noise=self.sensor.readout_noise,
             material=self.sensor.material,
             aperture_mechanical=optika.apertures.RectangularAperture(
                 half_width=self.sensor.width_package / 2,

--- a/esis/optics/_cameras/_cameras_test.py
+++ b/esis/optics/_cameras/_cameras_test.py
@@ -1,4 +1,5 @@
 import pytest
+import astropy.units as u
 import optika
 from msfc_ccd._tests.test_cameras import AbstractTestAbstractCamera
 import esis
@@ -8,6 +9,9 @@ import esis
     argnames="a",
     argvalues=[
         esis.optics.Camera(),
+        esis.optics.Camera(
+            sensor=esis.optics.Sensor(readout_noise=6 * u.electron),
+        ),
     ],
 )
 class TestCameras(
@@ -18,3 +22,11 @@ class TestCameras(
         a: esis.optics.abc.AbstractPrimaryMirror,
     ):
         assert isinstance(a.surface, optika.surfaces.AbstractSurface)
+
+    def test_surface_read_noise(
+        self,
+        a: esis.optics.Camera,
+    ):
+        result = a.surface.read_noise
+        assert result == a.sensor.readout_noise
+        assert result > 0 * u.electron

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "astropy~=7.2",
     "joblib",
     "named-arrays~=2.0",
-    "optika~=2.0,>=2.0.1",
+    "optika~=2.1",
     "msfc-ccd~=1.0",
     "solar-dynamics-observatory~=1.0",
     "interface-region-imaging-spectrograph~=1.0,>=1.0.1",


### PR DESCRIPTION
`esis.optics.Camera.surface` never set `read_noise` on the `optika.sensors.ImagingSensor` it constructs, so it silently fell back to the `0 * u.electron` default. Consequences:

- simulated exposures (`ImagingSensor.expose(noise=True)`) had no read noise, and
- `ImagingSensor.uncertainty()` left the read-noise term out of its quadrature sum.

The value configured on the sensor was discarded: 4 electron by default (`msfc_ccd.TeledyneCCD230`), and 6 electron for the ESIS-I flight model (`esis/flights/f1/optics/_instruments/_instruments.py`).

Units line up on both sides, `msfc_ccd`'s `readout_noise` and `optika`'s `read_noise` are both the per-pixel Gaussian standard deviation in electrons, so no conversion is needed. Read noise is still applied exactly once, in `ImagingSensor._integrate`; nothing in `esis` adds it separately.

## Test

`test_surface_read_noise` asserts the surface reports the sensor's value and that it is nonzero, and `TestCameras` is now also parametrized over a camera with a non-default read noise so the test catches a hard-coded value as well as the missing one. Both cases fail without the one-line fix (`0 electron != 4 electron` / `0 electron != 6 electron`).

Note for reviewers: `expose(noise=True)` is now genuinely stochastic for ESIS where it previously was not, so anything that compared simulated images against saved values will shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1vnGTv1rGLVxYGhfpYf7o