### PR TITLE
Apply the Al/Sc multilayer coating in the ESIS-II design factories

### DIFF
--- a/esis/flights/f2/optics/_instruments/_instruments.py
+++ b/esis/flights/f2/optics/_instruments/_instruments.py
@@ -4,6 +4,7 @@ import named_arrays as na
 import optika
 import esis
 from ... import wavelength_Ne_VII, wavelength_Si_XII, wavelength_HeNe
+from .. import materials
 
 __all__ = [
     "design_proposed",
@@ -114,6 +115,9 @@ def design_proposed(
     dz = z_filter - result.filter.translation.z
     result.filter.translation.z += dz
     result.camera.sensor.translation.z += dz
+
+    result.primary_mirror.material = materials.multilayer_AlSc()
+    result.grating.material = materials.multilayer_AlSc()
 
     return result
 
@@ -288,6 +292,9 @@ def design_guess(
         axis_channel=axis_channel,
         num_distribution=num_distribution,
     )
+
+    result.primary_mirror.material = materials.multilayer_AlSc()
+    result.grating.material = materials.multilayer_AlSc()
 
     w1 = wavelength_Ne_VII
     w2 = wavelength_Si_XII

--- a/esis/flights/f2/optics/materials/_materials.py
+++ b/esis/flights/f2/optics/materials/_materials.py
@@ -184,7 +184,7 @@ def multilayer_SiSc() -> optika.materials.MultilayerMirror:
                         ),
                     ),
                 ],
-                num_periods=10,
+                num_periods=5,
             ),
         ],
         substrate=optika.materials.Layer(


### PR DESCRIPTION
## Summary

The proposed ESIS-II coatings `esis.flights.f2.optics.materials.multilayer_AlSc/SiSc` were defined and exported, but no `f2` factory ever assigned them — the instrument silently inherited the ESIS-I coatings (optimized for 557–667 Å), which reflect only 3–5% across the 430–534 Å ESIS-II passband. The modeled single-channel effective area was ~10⁻³ cm², suppressing synthetic count rates by two orders of magnitude.

Changes:

- `design_proposed()` and `design_guess()` now assign `multilayer_AlSc()` to both the primary and the grating, so `design_single()` and `design()` inherit it. Standalone, the Al/Sc model peaks at R ≈ 0.59 near 472 Å, matching the modeled coating prescription (N=10, d=257 Å, Γ=0.5, 7 Å interfaces).
- `multilayer_SiSc` corrected from 10 to 5 periods to match its prescription. It stays available as the flatter alternative.

## Effective area after the change

| line | A_eff |
|---|---|
| Ne VII 465.2 Å | 0.163 cm² |
| Si XII 499.4 Å | 0.062 cm² |
| Si XII 520.7 Å | 0.001 cm² |

Biasing the peak toward Ne VII roughly equalizes the detector count rates of the two line images for active-region scenes (a DEM-based forward model of the 2016-07-15 AR pair gives Ne VII : Si XII ≈ 1 : 1.35), and suppresses the Si XII 520.7 Å image, removing the third overlapping octagon from the detector. Using `multilayer_SiSc` on the grating instead trades some Ne VII throughput for band flatness and keeps 520.7 Å at ~25% of 499.4 Å.

## Testing

- `pytest esis/flights/f2` — 12 passed
- `black --check` / `ruff check` clean on both files
- Raytrace audit: primary reflectivity at the surface is now 57.6% / 37.8% at Ne VII / Si XII (was 2.7% / 5.1%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)