### PR TITLE
Take scale factors as arguments in `scene_iris` instead of measuring the spectral window

### DIFF
--- a/esis/data/synth/_scene_iris/_scene_iris.py
+++ b/esis/data/synth/_scene_iris/_scene_iris.py
@@ -15,8 +15,7 @@ def scene_iris(
     time_stop: None | str | astropy.time.Time,
     wavelength_rest: u.Quantity,
     radiance: u.Quantity,
-    fwhm: u.Quantity,
-    fwhm_source: u.Quantity,
+    velocity_scale: float,
     axis_time: str = "time",
     axis_detector_x: str = "detector_x",
     axis_detector_y: str = "detector_y",
@@ -51,18 +50,12 @@ def scene_iris(
     radiance
         The average radiance of the simulated scene.
         This replaces the actual radiance of the IRIS observations.
-    fwhm
-        The average full-width half maximum, in wavelength units, of the
-        dominant spectral line in the simulated scene.
-        The wavelength axis of the IRIS observations will be scaled to match
-        this value.
-    fwhm_source
-        The average full-width half maximum, in wavelength units, of the
-        spectral line in the IRIS observations which is being shifted and
-        scaled onto `wavelength_rest`.
-        This is given rather than measured because the spectral window
-        usually contains several lines, and the width of the blend is not the
-        width of the line.
+    velocity_scale
+        The factor by which to scale the Doppler velocity of the IRIS
+        observations.
+        Since the line being simulated is not the line which was observed,
+        the velocity axis has to be stretched or compressed to give the
+        simulated line a realistic width.
     axis_time
         The logical axis corresponding to changes in time.
     axis_detector_x
@@ -148,10 +141,8 @@ def scene_iris(
 
     scene.outputs[scene.outputs < dn_min] = dn_zero
 
-    scale = (fwhm / wavelength_rest) / (fwhm_source / scene.inputs.wavelength_rest)
-
     scene.inputs = na.TemporalDopplerPositionalVectorArray.from_velocity(
-        velocity=scene.inputs.velocity * scale,
+        velocity=scene.inputs.velocity * velocity_scale,
         wavelength_rest=wavelength_rest,
         time=scene.inputs.time,
         position=scene.inputs.position,

--- a/esis/data/synth/_scene_iris/_scene_iris.py
+++ b/esis/data/synth/_scene_iris/_scene_iris.py
@@ -14,7 +14,7 @@ def scene_iris(
     time_start: str | astropy.time.Time,
     time_stop: None | str | astropy.time.Time,
     wavelength_rest: u.Quantity,
-    radiance: u.Quantity,
+    radiance_scale: float,
     velocity_scale: float,
     axis_time: str = "time",
     axis_detector_x: str = "detector_x",
@@ -47,9 +47,13 @@ def scene_iris(
     wavelength_rest
         The new rest wavelength of the simulated scene.
         This replaces the actual rest wavelength of the IRIS observations.
-    radiance
-        The average radiance of the simulated scene.
-        This replaces the actual radiance of the IRIS observations.
+    radiance_scale
+        The factor by which to scale the radiance of the IRIS observations.
+        The observations are first converted from instrument units to
+        radiometric units using
+        :attr:`iris.sg.SpectrographObservation.radiance`,
+        so this only has to account for the difference in brightness between
+        the line being simulated and the line which was observed.
     velocity_scale
         The factor by which to scale the Doppler velocity of the IRIS
         observations.
@@ -141,18 +145,18 @@ def scene_iris(
 
     scene.outputs[scene.outputs < dn_min] = dn_zero
 
+    # This has to happen while the coordinates are still those of the IRIS
+    # observation, since the conversion needs the exposure length and the
+    # size of a pixel on the sky and in wavelength.
+    scene = scene.radiance
+
+    scene.outputs = scene.outputs * radiance_scale
+
     scene.inputs = na.TemporalDopplerPositionalVectorArray.from_velocity(
         velocity=scene.inputs.velocity * velocity_scale,
         wavelength_rest=wavelength_rest,
         time=scene.inputs.time,
         position=scene.inputs.position,
     )
-
-    radiance_avg = scene.integrate(
-        component="wavelength",
-        axis=axis_velocity,
-    ).outputs.mean()
-
-    scene.outputs = scene.outputs * radiance / radiance_avg
 
     return scene

--- a/esis/data/synth/_scene_iris/_scene_iris.py
+++ b/esis/data/synth/_scene_iris/_scene_iris.py
@@ -124,23 +124,6 @@ def scene_iris(
 
         scene.outputs = scene.outputs - bg
 
-    if velocity_max is not None:
-        velocity_centers = scene.inputs.velocity.cell_centers(axis_velocity)
-
-        where_upper = +velocity_max < velocity_centers
-
-        index_lower = np.nanargmax(-velocity_max < velocity_centers)[axis_velocity]
-        index_lower = index_lower.ndarray
-
-        if where_upper.any():
-            index_upper = np.nanargmax(where_upper)[axis_velocity].ndarray
-        else:
-            index_upper = None
-
-        crop_wavelength = {scene.axis_wavelength: slice(index_lower, index_upper)}
-
-        scene = scene[crop_wavelength]
-
     scene.outputs = np.nan_to_num(scene.outputs)
 
     scene.outputs[scene.outputs < dn_min] = dn_zero
@@ -158,5 +141,24 @@ def scene_iris(
         time=scene.inputs.time,
         position=scene.inputs.position,
     )
+
+    # Cropped after the velocity has been scaled, so that the limit is a
+    # velocity in the simulated scene rather than in the observations.
+    if velocity_max is not None:
+        velocity_centers = scene.inputs.velocity.cell_centers(axis_velocity)
+
+        where_upper = +velocity_max < velocity_centers
+
+        index_lower = np.nanargmax(-velocity_max < velocity_centers)[axis_velocity]
+        index_lower = index_lower.ndarray
+
+        if where_upper.any():
+            index_upper = np.nanargmax(where_upper)[axis_velocity].ndarray
+        else:
+            index_upper = None
+
+        crop_wavelength = {scene.axis_wavelength: slice(index_lower, index_upper)}
+
+        scene = scene[crop_wavelength]
 
     return scene

--- a/esis/data/synth/_scene_iris/_scene_iris.py
+++ b/esis/data/synth/_scene_iris/_scene_iris.py
@@ -16,6 +16,7 @@ def scene_iris(
     wavelength_rest: u.Quantity,
     radiance: u.Quantity,
     fwhm: u.Quantity,
+    fwhm_source: u.Quantity,
     axis_time: str = "time",
     axis_detector_x: str = "detector_x",
     axis_detector_y: str = "detector_y",
@@ -55,6 +56,13 @@ def scene_iris(
         dominant spectral line in the simulated scene.
         The wavelength axis of the IRIS observations will be scaled to match
         this value.
+    fwhm_source
+        The average full-width half maximum, in wavelength units, of the
+        spectral line in the IRIS observations which is being shifted and
+        scaled onto `wavelength_rest`.
+        This is given rather than measured because the spectral window
+        usually contains several lines, and the width of the blend is not the
+        width of the line.
     axis_time
         The logical axis corresponding to changes in time.
     axis_detector_x
@@ -92,6 +100,7 @@ def scene_iris(
     scene = iris.sg.open(
         time=time_start,
         time_stop=time_stop,
+        axis_time=axis_time,
         axis_wavelength=axis_velocity,
         axis_detector_x=axis_detector_x,
         axis_detector_y=axis_detector_y,
@@ -139,15 +148,7 @@ def scene_iris(
 
     scene.outputs[scene.outputs < dn_min] = dn_zero
 
-    spectrum = scene.mean((axis_time, axis_detector_x, axis_detector_y))
-
-    fwhm_avg = na.pdf.fwhm(
-        x=spectrum.inputs.wavelength,
-        f=spectrum.outputs,
-        axis=axis_velocity,
-    )
-
-    scale = (fwhm / wavelength_rest) / (fwhm_avg / scene.inputs.wavelength_rest)
+    scale = (fwhm / wavelength_rest) / (fwhm_source / scene.inputs.wavelength_rest)
 
     scene.inputs = na.TemporalDopplerPositionalVectorArray.from_velocity(
         velocity=scene.inputs.velocity * scale,

--- a/esis/flights/f1/data/synth/__init__.py
+++ b/esis/flights/f1/data/synth/__init__.py
@@ -1,10 +1,15 @@
 """Create synthetic solar scenes that can be observed with an instrument model."""
 
 from ._scene_aia import scene_aia
-from ._scene_iris import velocity_scale_default, scene_iris
+from ._scene_iris import (
+    radiance_scale_default,
+    velocity_scale_default,
+    scene_iris,
+)
 
 __all__ = [
     "scene_aia",
+    "radiance_scale_default",
     "velocity_scale_default",
     "scene_iris",
 ]

--- a/esis/flights/f1/data/synth/__init__.py
+++ b/esis/flights/f1/data/synth/__init__.py
@@ -1,9 +1,10 @@
 """Create synthetic solar scenes that can be observed with an instrument model."""
 
 from ._scene_aia import scene_aia
-from ._scene_iris import scene_iris
+from ._scene_iris import velocity_scale_default, scene_iris
 
 __all__ = [
     "scene_aia",
+    "velocity_scale_default",
     "scene_iris",
 ]

--- a/esis/flights/f1/data/synth/_scene_iris/__init__.py
+++ b/esis/flights/f1/data/synth/_scene_iris/__init__.py
@@ -1,6 +1,11 @@
-from ._scene_iris import velocity_scale_default, scene_iris
+from ._scene_iris import (
+    radiance_scale_default,
+    velocity_scale_default,
+    scene_iris,
+)
 
 __all__ = [
+    "radiance_scale_default",
     "velocity_scale_default",
     "scene_iris",
 ]

--- a/esis/flights/f1/data/synth/_scene_iris/__init__.py
+++ b/esis/flights/f1/data/synth/_scene_iris/__init__.py
@@ -1,5 +1,6 @@
-from ._scene_iris import scene_iris
+from ._scene_iris import velocity_scale_default, scene_iris
 
 __all__ = [
+    "velocity_scale_default",
     "scene_iris",
 ]

--- a/esis/flights/f1/data/synth/_scene_iris/_scene_iris.py
+++ b/esis/flights/f1/data/synth/_scene_iris/_scene_iris.py
@@ -6,9 +6,15 @@ import esis
 from ....spectrum import O_V, Si_IV
 
 __all__ = [
+    "radiance_scale_default",
     "velocity_scale_default",
     "scene_iris",
 ]
+
+#: The default factor by which the radiance of the IRIS observations is
+#: scaled, which is the ratio of the average quiet-sun radiances of the
+#: simulated and observed lines.
+radiance_scale_default = float(O_V.radiance / Si_IV.radiance)
 
 #: The default factor by which the Doppler velocity of the IRIS observations
 #: is scaled, which maps the average quiet-sun width of the observed line onto
@@ -22,7 +28,7 @@ def scene_iris(
     time_start: str | astropy.time.Time,
     time_stop: None | str | astropy.time.Time = None,
     wavelength_rest: u.Quantity = O_V.wavelength,
-    radiance: u.Quantity = O_V.radiance,
+    radiance_scale: float = radiance_scale_default,
     velocity_scale: float = velocity_scale_default,
     axis_time: str = "time",
     axis_detector_x: str = "detector_x",
@@ -56,9 +62,10 @@ def scene_iris(
     wavelength_rest
         The new rest wavelength of the simulated scene.
         This replaces the actual rest wavelength of the IRIS observations.
-    radiance
-        The average radiance of the simulated scene.
-        This replaces the actual radiance of the IRIS observations.
+    radiance_scale
+        The factor by which to scale the radiance of the IRIS observations.
+        Defaults to the ratio of the average quiet-sun radiances of the
+        simulated and observed lines, see :obj:`radiance_scale_default`.
     velocity_scale
         The factor by which to scale the Doppler velocity of the IRIS
         observations.
@@ -110,7 +117,7 @@ def scene_iris(
         time_start=time_start,
         time_stop=time_stop,
         wavelength_rest=wavelength_rest,
-        radiance=radiance,
+        radiance_scale=radiance_scale,
         velocity_scale=velocity_scale,
         axis_time=axis_time,
         axis_detector_x=axis_detector_x,

--- a/esis/flights/f1/data/synth/_scene_iris/_scene_iris.py
+++ b/esis/flights/f1/data/synth/_scene_iris/_scene_iris.py
@@ -6,8 +6,16 @@ import esis
 from ....spectrum import O_V, Si_IV
 
 __all__ = [
+    "velocity_scale_default",
     "scene_iris",
 ]
+
+#: The default factor by which the Doppler velocity of the IRIS observations
+#: is scaled, which maps the average quiet-sun width of the observed line onto
+#: the average quiet-sun width of the simulated line.
+velocity_scale_default = float(
+    (O_V.fwhm / O_V.wavelength) / (Si_IV.fwhm / Si_IV.wavelength)
+)
 
 
 def scene_iris(
@@ -15,8 +23,7 @@ def scene_iris(
     time_stop: None | str | astropy.time.Time = None,
     wavelength_rest: u.Quantity = O_V.wavelength,
     radiance: u.Quantity = O_V.radiance,
-    fwhm: u.Quantity = O_V.fwhm,
-    fwhm_source: u.Quantity = Si_IV.fwhm,
+    velocity_scale: float = velocity_scale_default,
     axis_time: str = "time",
     axis_detector_x: str = "detector_x",
     axis_detector_y: str = "detector_y",
@@ -52,17 +59,11 @@ def scene_iris(
     radiance
         The average radiance of the simulated scene.
         This replaces the actual radiance of the IRIS observations.
-    fwhm
-        The average full-width half maximum, in wavelength units, of the
-        dominant spectral line in the simulated scene.
-        The wavelength axis of the IRIS observations will be scaled to match
-        this value.
-    fwhm_source
-        The average full-width half maximum, in wavelength units, of the
-        spectral line in the IRIS observations which is being shifted and
-        scaled onto `wavelength_rest`.
-        Defaults to the average quiet-sun width of
-        :math:`\text{Si\,IV}\;1394\,\AA`, the line in the default window.
+    velocity_scale
+        The factor by which to scale the Doppler velocity of the IRIS
+        observations.
+        Defaults to the ratio of the average quiet-sun widths of the simulated
+        and observed lines, see :obj:`velocity_scale_default`.
     axis_time
         The logical axis corresponding to changes in time.
     axis_detector_x
@@ -110,8 +111,7 @@ def scene_iris(
         time_stop=time_stop,
         wavelength_rest=wavelength_rest,
         radiance=radiance,
-        fwhm=fwhm,
-        fwhm_source=fwhm_source,
+        velocity_scale=velocity_scale,
         axis_time=axis_time,
         axis_detector_x=axis_detector_x,
         axis_detector_y=axis_detector_y,

--- a/esis/flights/f1/data/synth/_scene_iris/_scene_iris.py
+++ b/esis/flights/f1/data/synth/_scene_iris/_scene_iris.py
@@ -3,7 +3,7 @@ import astropy.units as u
 import astropy.time
 import named_arrays as na
 import esis
-from ....spectrum import O_V
+from ....spectrum import O_V, Si_IV
 
 __all__ = [
     "scene_iris",
@@ -16,6 +16,7 @@ def scene_iris(
     wavelength_rest: u.Quantity = O_V.wavelength,
     radiance: u.Quantity = O_V.radiance,
     fwhm: u.Quantity = O_V.fwhm,
+    fwhm_source: u.Quantity = Si_IV.fwhm,
     axis_time: str = "time",
     axis_detector_x: str = "detector_x",
     axis_detector_y: str = "detector_y",
@@ -56,6 +57,12 @@ def scene_iris(
         dominant spectral line in the simulated scene.
         The wavelength axis of the IRIS observations will be scaled to match
         this value.
+    fwhm_source
+        The average full-width half maximum, in wavelength units, of the
+        spectral line in the IRIS observations which is being shifted and
+        scaled onto `wavelength_rest`.
+        Defaults to the average quiet-sun width of
+        :math:`\text{Si\,IV}\;1394\,\AA`, the line in the default window.
     axis_time
         The logical axis corresponding to changes in time.
     axis_detector_x
@@ -104,6 +111,7 @@ def scene_iris(
         wavelength_rest=wavelength_rest,
         radiance=radiance,
         fwhm=fwhm,
+        fwhm_source=fwhm_source,
         axis_time=axis_time,
         axis_detector_x=axis_detector_x,
         axis_detector_y=axis_detector_y,

--- a/esis/flights/f1/data/synth/_scene_iris/_scene_iris_test.py
+++ b/esis/flights/f1/data/synth/_scene_iris/_scene_iris_test.py
@@ -43,3 +43,9 @@ def test_scene_iris(
     radiance = result.integrate(component="wavelength", axis=axis_velocity)
     assert np.all(np.isfinite(radiance.outputs))
     assert np.all(radiance.outputs > 0)
+
+    # The limit is a velocity in the simulated scene, not in the observations,
+    # so it has to hold after the velocity has been scaled. It applies to the
+    # center of each cell, the edges of the outermost cells lie beyond it.
+    velocity = result.inputs.velocity.cell_centers(axis_velocity)
+    assert np.all(np.abs(velocity) <= velocity_max)

--- a/esis/flights/f1/data/synth/_scene_iris/_scene_iris_test.py
+++ b/esis/flights/f1/data/synth/_scene_iris/_scene_iris_test.py
@@ -41,4 +41,5 @@ def test_scene_iris(
     assert np.all(result.inputs.wavelength_rest == O_V.wavelength)
 
     radiance = result.integrate(component="wavelength", axis=axis_velocity)
-    assert np.allclose(radiance.outputs.mean(), O_V.radiance, rtol=1e-1)
+    assert np.all(np.isfinite(radiance.outputs))
+    assert np.all(radiance.outputs > 0)

--- a/esis/flights/f1/data/synth/_scene_iris/_scene_iris_test.py
+++ b/esis/flights/f1/data/synth/_scene_iris/_scene_iris_test.py
@@ -1,7 +1,6 @@
 import pytest
 import numpy as np
 import astropy.units as u
-import named_arrays as na
 import esis
 from esis.flights.f1.spectrum import O_V
 
@@ -21,7 +20,6 @@ def test_scene_iris(
     axis_time = "time"
     axis_x = "detector_x"
     axis_y = "detector_y"
-    axis_txy = (axis_time, axis_x, axis_y)
     axis_velocity = "velocity"
 
     try:
@@ -44,11 +42,3 @@ def test_scene_iris(
 
     radiance = result.integrate(component="wavelength", axis=axis_velocity)
     assert np.allclose(radiance.outputs.mean(), O_V.radiance, rtol=1e-1)
-
-    spectrum = result.mean(axis_txy)
-    fwhm = na.pdf.fwhm(
-        x=spectrum.inputs.wavelength,
-        f=spectrum.outputs,
-        axis=axis_velocity,
-    )
-    assert np.allclose(fwhm, O_V.fwhm, rtol=1e-1)

--- a/esis/flights/f1/spectrum/Si_IV.py
+++ b/esis/flights/f1/spectrum/Si_IV.py
@@ -11,12 +11,18 @@ import astropy.units as u
 
 __all__ = [
     "wavelength",
+    "radiance",
     "fwhm",
     "width_doppler",
 ]
 
 #: Rest wavelength calculated by the Chianti Atomic Database :cite:p:`Dere1997`.
 wavelength = 1393.755 * u.AA
+
+#: Average quiet-sun radiance, measured by integrating an IRIS raster over the
+#: line and averaging over the field of view. The mean is used rather than the
+#: median since this is meant to be the average over an area of the Sun.
+radiance = 361.70 * u.erg / u.cm**2 / u.sr / u.s
 
 #: Average quiet-sun full width at half maximum, measured from the median
 #: spectral profile of an IRIS raster. The median is used rather than the mean

--- a/esis/flights/f1/spectrum/Si_IV.py
+++ b/esis/flights/f1/spectrum/Si_IV.py
@@ -1,0 +1,32 @@
+r"""
+Properties of the :math:`\text{Si\,IV}\;1394\,\AA` spectral line.
+
+This line is not observed by ESIS. It is the line observed by IRIS which is
+shifted and scaled onto :math:`\text{O\,V}\;630\,\AA` by
+:func:`esis.data.synth.scene_iris` to synthesize a scene.
+"""
+
+import numpy as np
+import astropy.units as u
+
+__all__ = [
+    "wavelength",
+    "fwhm",
+    "width_doppler",
+]
+
+#: Rest wavelength calculated by the Chianti Atomic Database :cite:p:`Dere1997`.
+wavelength = 1393.755 * u.AA
+
+#: Average quiet-sun full width at half maximum, measured from the median
+#: spectral profile of an IRIS raster. The median is used rather than the mean
+#: so that the value is not biased by the bright, broad profiles of transient
+#: events.
+fwhm = 0.151 * u.AA
+
+_width = fwhm / (2 * np.sqrt(2 * np.log(2)))
+
+_eq = u.doppler_optical(wavelength)
+
+#: Average quiet-sun Doppler width computed from :attr:`fwhm`.
+width_doppler = (wavelength + _width).to(u.km / u.s, equivalencies=_eq)

--- a/esis/flights/f1/spectrum/__init__.py
+++ b/esis/flights/f1/spectrum/__init__.py
@@ -3,9 +3,11 @@
 from . import O_V
 from . import Mg_X
 from . import He_I
+from . import Si_IV
 
 __all__ = [
     "O_V",
     "Mg_X",
     "He_I",
+    "Si_IV",
 ]


### PR DESCRIPTION
## The problem

`scene_iris` made two measurements across the whole spectral window and used them to set the width and the brightness of the simulated line:

```python
fwhm_avg = na.pdf.fwhm(x=spectrum.inputs.wavelength, f=spectrum.outputs, axis=axis_velocity)
scale = (fwhm / wavelength_rest) / (fwhm_avg / scene.inputs.wavelength_rest)
...
radiance_avg = scene.integrate(component="wavelength", axis=axis_velocity).outputs.mean()
scene.outputs = scene.outputs * radiance / radiance_avg
```

Both are only measurements of a line if the window holds a single line. The `Si IV 1394` window holds several, so what was measured was the width and the brightness of the blend.

Measured on the raster this was found with:

| quantity | value |
| --- | --- |
| width across the full window (what was used) | 9.12 Å |
| width of the Si IV line alone | 0.15 Å |
| resulting velocity scale factor | 0.031 |
| fraction of the integrated radiance inside the line | 79% |

The velocity axis was compressed by a factor of about sixty, which made the scene unusable, and the line came out about a fifth too faint.

## The change

Take the two scale factors as arguments, `velocity_scale` and `radiance_scale`, and remove both measurements.

For the radiance this is only possible because the observations can be put into physical units first, with `SpectrographObservation.radiance`, which uses the effective area, the gain, the size of a pixel on the sky and in wavelength, and the exposure length. The scale factor is then dimensionless and only has to account for the difference in brightness between the line being simulated and the line which was observed.

The flight-specific wrapper derives both defaults from the average quiet-sun properties of the two lines, since that is where the numbers come from:

```python
radiance_scale_default = float(O_V.radiance / Si_IV.radiance)                                   # 0.926
velocity_scale_default = float((O_V.fwhm / O_V.wavelength) / (Si_IV.fwhm / Si_IV.wavelength))   # 1.891
```

`Si_IV` is added to `esis.flights.f1.spectrum` to hold the properties of the observed line.

An earlier version of this branch took the *width* of the observed line rather than the scale factor. That is worse in two ways: the caller supplies two quantities to control one, and it implies a guarantee the function cannot keep, since the simulated line only comes out at the requested width if the observation matches the assumed average. Taking the factors directly makes the contract exactly what the function does.

## `velocity_max`

Also moved to after the scaling. It is documented as the maximum Doppler velocity of the simulated scene, but the crop happened first, so the limit was a velocity in the observations and the scene came out wider than asked for by whatever the scale factor was. With the defaults, asking for 100 km/s gave a scene reaching 189.

This was easy to miss because with the old scale factor the limit never did anything at all: the whole window had been compressed inside it.

## The test

Two assertions are removed, on the width and on the radiance of the simulated scene. Neither tested the transformation: the same measurement was used to set the scale factor and to check the result, so they passed for any scale factor at all, including the one that was wrong by a factor of sixty. Restricting the width measurement to the neighbourhood of the line does not help; it returns exactly the same number.

In their place the scene is checked to be finite and positive, and `velocity_max` is checked to hold, which it did not before. The assertions on units and rest wavelength are unchanged. All four parametrizations pass locally.

If you would like the test to check the scaling itself, the honest way is linearity: call twice with `radiance_scale` and `2 * radiance_scale` and assert the outputs differ by exactly two. That costs a second run against the IRIS archive, so I have not assumed it.

## Notes for the reviewer

- **Neither `Si_IV` value is cited.** `fwhm = 0.151 Å` is the width of the median spectral profile of a quiet-sun IRIS raster, median so that bright transients do not bias it; inverting it gives a non-thermal velocity of 18.3 km/s at log T = 4.9, which is mid-range for the quiet transition region. `radiance = 361.70 erg / (cm2 sr s)` is that raster integrated over the line and averaged over the field of view, mean rather than median since it is meant to be an average over an area of the Sun. `O_V.py` cites published values and this should probably do the same.
- **`Si_IV.py` lives in `flights/f1/spectrum/`**, whose docstring says these are lines observed during the flight. Si IV is not; it is the line the synthetic scene is built from. The module docstring says so, but a general spectrum module may be a better home.
- **`axis_time` is now passed to `iris.sg.open`.** Removing the width measurement left it as the only use of that parameter. It should have been forwarded anyway: a caller passing a custom `axis_time` was previously ignored.
