### PR TITLE
Take the Si IV radiance from the literature, not from the raster

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -85,6 +85,19 @@ URL = {https://doi.org/10.1117/12.2313346}
     doi = {10.1364/AO.43.002029},
     abstract = {Performances are presented of three classes of imaging slit spectrometers for extended sources with aberration-corrected gratings. A general analytical expression for minimizing off-axis grating aberrations is obtained, and it is demonstrated that these aberrations are minimized when the spectrometer is operated at a magnification higher than unity. Classical designs with toroidal uniform-line-spaced (TULS) or spherical varied-line-space (SVLS) gratings are compared with a new class of designs that utilize toroidal varied-line-space (TVLS) gratings. Although TULS and SVLS designs with two stigmatic points can be designed to operate at near-unity magnification with excellent on-axis spectral and spatial resolutions, they cannot be made to satisfy the general off-axis condition, and so their off-axis performances are not optimum. On the contrary TVLS designs with two stigmatic points can be operated at almost any magnification, thus satisfying the off-axis condition perfectly. Such designs are suitable for imaging spectrometer observations that require an extended field of view.},
 }
+@ARTICLE{Brekke1993,
+       author = {{Brekke}, P.},
+        title = "{An Ultraviolet Spectral Atlas of the Sun between 1190 and 1730 Angstroms Observed with the High Resolution Telescope and Spectrograph}",
+      journal = {pjs},
+     keywords = {Solar Spectra, Spectral Emission, Ultraviolet Spectra, Atlases, Line Spectra, Solar Physics, Sun: Chromosphere, Sun: Transition Region, Sun: UV Radiation},
+         year = 1993,
+        month = aug,
+       volume = {87},
+        pages = {443},
+          doi = {10.1086/191810},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/1993ApJS...87..443B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 @ARTICLE{Vernazza1978,
        author = {{Vernazza}, J.~E. and {Reeves}, E.~M.},
         title = "{Extreme ultraviolet composite spectra of representative solar features.}",

--- a/esis/flights/f1/spectrum/Si_IV.py
+++ b/esis/flights/f1/spectrum/Si_IV.py
@@ -19,10 +19,15 @@ __all__ = [
 #: Rest wavelength calculated by the Chianti Atomic Database :cite:p:`Dere1997`.
 wavelength = 1393.755 * u.AA
 
-#: Average quiet-sun radiance, measured by integrating an IRIS raster over the
-#: line and averaging over the field of view. The mean is used rather than the
-#: median since this is meant to be the average over an area of the Sun.
-radiance = 361.70 * u.erg / u.cm**2 / u.sr / u.s
+#: Average quiet-sun radiance measured by :cite:t:`Brekke1993` with the High
+#: Resolution Telescope and Spectrograph.
+#:
+#: Taken from the literature rather than measured from the raster being
+#: scaled, so that the ratio of this to the radiance of the simulated line is
+#: a property of the two lines rather than of the observation. Measuring it
+#: from the raster would divide the observation by itself, which would give
+#: every scene the same brightness however bright the Sun was that day.
+radiance = 280.0 * u.erg / u.cm**2 / u.sr / u.s
 
 #: Average quiet-sun full width at half maximum, measured from the median
 #: spectral profile of an IRIS raster. The median is used rather than the mean


### PR DESCRIPTION
`Si_IV.radiance` was measured by integrating the very IRIS raster that
`scene_iris` shifts and scales onto O V, and it is the denominator of
`radiance_scale_default`. The scale factor therefore divided the observation
by itself: whatever the Sun was doing on the day of the raster, the synthetic
scene came out at the same brightness, and a quiet region and an active one
would have produced equally bright scenes.

It is now the value measured with the High Resolution Telescope and
Spectrograph by Brekke (1993), whose atlas covers 1190–1730 Å and so includes
this line. The ratio of it to the radiance of the simulated line is then a
property of the two lines rather than of the observation, and a scene built
from a faint region is faint.

| | before | after |
|---|---|---|
| `Si_IV.radiance` | 361.70 (measured from the raster) | 280.0 (Brekke 1993) |
| `radiance_scale_default` | 0.926 | 1.196 |

The scene comes out about 29% brighter than the measured value gave.

Adds a `Brekke1993` entry to `docs/refs.bib` so the `:cite:t:` resolves.

### Worth a second opinion

The 280.0 is the observed quiet-Sun radiance tabulated for Si IV 1393.78 in
the transition-region benchmark of Dufresne, Del Zanna & Mason (2023), which
states that its radiances for lines longward of ~1200 Å come from Brekke's
HRTS atlas. I could not open the published Table 3 to confirm the per-row
footnote, so if anyone with access can check that the Si IV row is attributed
to Brekke rather than to Warren (2005) — whose spectrum stops at 1200 Å and
so cannot be the source — that would settle the citation.

Note also that "average quiet Sun" Si IV carries real scatter: Brekke has
four quiet-Sun regions, and IRIS sees this line range over roughly 20 to 1000
erg cm⁻² s⁻¹ sr⁻¹ across a field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCSQYdjmBmHxQEvbFez3rF